### PR TITLE
Autogenerate releases

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Generate Binaries
+name: Create Release
 
 on:
   workflow_dispatch:
@@ -9,10 +9,11 @@ env:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-    - uses: actions/checkout@v2
-
+    
     - name: Show toolchain
       run: rustup show
 
@@ -22,14 +23,15 @@ jobs:
     - name: Build
       run: cargo build --release --target=x86_64-unknown-linux-musl --bin librarian --bin server
       
-    - uses: actions/upload-artifact@v2
-      name: Save Librarian cli
+    - name: Create binary tar archive
+      run: tar --create --gzip --file=librarian_binaries.tar.gz target/x86_64-unknown-linux-musl/release/librarian target/x86_64-unknown-linux-musl/release/server
+      
+    - name: Create gzip for CLI
+      run: gzip target/x86_64-unknown-linux-musl/release/librarian
+        
+    - uses: ncipollo/release-action@v1.12.0
+      name: Generate draft release
       with:
-        name: librarian-cli
-        path: target/x86_64-unknown-linux-musl/release/librarian
-
-    - uses: actions/upload-artifact@v2
-      name: Save server
-      with:
-        name: librarian-server
-        path: target/x86_64-unknown-linux-musl/release/server
+        artifacts: librarian_binaries.tar.gz, target/x86_64-unknown-linux-musl/release/librarian.gz
+        artifactErrorsFailBuild: true
+        draft: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <center>
 <img src="frontend/static/favicon.ico" />
 
+![GitHub release (latest by date)](https://img.shields.io/github/v/release/DesmondWillowbrook/Librarian?display_name=release)
+
 # Librarian 
 </center>
 
@@ -27,6 +29,8 @@ To that end, Librarian produces several plots to help identify library types. Fo
 > How to interpret: Some regions on the map are very specific to a certain library type, others are more mixed. Therefore, for some test libraries the results will be much clearer than for others. The different plots are intended to provide a good overview of how similar the test library is to published data. The cause of any deviations should be inspected; the interpretation will be different depending on how characteristic the composition signature of the library type and how far off the projection of the test sample is.
 
 You can try Librarian at the [Babraham Institute website](https://www.bioinformatics.babraham.ac.uk/librarian/), run a [tool to query samples from the command-line](cli/README.md), or [set up the server yourself](server/README.md).
+
+**Download releases [here](https://github.com/DesmondWillowbrook/Librarian/releases).**
 
 ## Folder Structure
 - `frontend` contains code for the website, which consists of the webpage and WebAssembly code responsible for extracting base compositions from given files. Extracted base compositions are sent to the server for plotting.

--- a/server/README.md
+++ b/server/README.md
@@ -1,4 +1,7 @@
 # Server
+
+The server runs the data processing and visualization code.
+
 Serves the webpages in `frontend/dist` along with running backend services.
 ## Setup:
 


### PR DESCRIPTION
Also generate tar archives of binaries.

@ChristelKrueger Is providing a `librarian_binaries.tar.gz` and something like `librarian-cli.gz` better? I'll add in some documentation in the README as well.