### PR TITLE
Fixes for compilation and execution

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,8 +10,8 @@ npm --version && \
 	Rscript --version \
 
 cd frontend
-#npm install
-#npm run build
+npm install
+npm run build
 cd ..
 
 cd server

--- a/server/scripts/Librarian_analysis.Rmd
+++ b/server/scripts/Librarian_analysis.Rmd
@@ -33,7 +33,7 @@ args = commandArgs(trailingOnly=TRUE)
 
 ## creating the pin board
 
-board <- board_folder("./scripts")
+board <- board_folder(".")
 
 ## loading the pinned model and coordinates
 


### PR DESCRIPTION
We did a big debug session today.  The two fixes here are:

1. The run.sh script had the npm commands commented out so the frontend build never happened.
2. The path for the pinboard was wrong in the Rmd file.  In an Rmd file the working directory is always set to the directory the Rmd file is in so you don't need to modify that when creating the objects at runtime.